### PR TITLE
Fix some include paths behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
 
 RUN apt-get update && \
-    apt-get install -y build-essential && \
+    apt-get install -y build-essential git && \
     bundle && \
     apt-get remove -y build-essential
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "mdl", "~> 0.2"
+gem "mdl", git: "https://github.com/wfleming/markdownlint", ref: "8143d80"
 gem "posix-spawn"
 gem "rake"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,18 @@
+GIT
+  remote: https://github.com/wfleming/markdownlint
+  revision: 8143d80a31b6f803bdc0f0b90ada3971546d167b
+  ref: 8143d80
+  specs:
+    mdl (0.2.1)
+      kramdown (~> 1.8, >= 1.8.0)
+      mixlib-cli (~> 1.5, >= 1.5.0)
+      mixlib-config (~> 2.1, >= 2.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    kramdown (1.9.0)
-    mdl (0.2.1)
-      kramdown (~> 1.5, >= 1.5.0)
-      mixlib-cli (~> 1.5, >= 1.5.0)
-      mixlib-config (~> 2.1, >= 2.1.0)
+    kramdown (1.10.0)
     mixlib-cli (1.5.0)
     mixlib-config (2.2.1)
     posix-spawn (0.3.11)
@@ -29,10 +35,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  mdl (~> 0.2)
+  mdl!
   posix-spawn
   rake
   rspec
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/cc/engine/markdownlint.rb
+++ b/lib/cc/engine/markdownlint.rb
@@ -40,7 +40,7 @@ module CC
         return root unless engine_config.has_key?("include_paths")
 
         markdown_files = engine_config["include_paths"].select do |path|
-          EXTENSIONS.include?(File.extname(path))
+          EXTENSIONS.include?(File.extname(path)) || path.end_with?("/")
         end
 
         Shellwords.join(markdown_files)
@@ -49,7 +49,7 @@ module CC
       def issue(line)
         match_data = line.match(/(?<filename>[^:]*):(?<line>\d+): (?<code>MD\d+) (?<description>.*)/)
         line = match_data[:line].to_i
-        filename = match_data[:filename].sub(root + "/", "")
+        filename = File.absolute_path(match_data[:filename]).sub(root + "/", "")
         content = content(match_data[:code])
 
         {

--- a/lib/cc/engine/markdownlint.rb
+++ b/lib/cc/engine/markdownlint.rb
@@ -5,6 +5,8 @@ require "posix/spawn"
 module CC
   module Engine
     class Markdownlint
+      EXTENSIONS = %w[.markdown .md].freeze
+
       def initialize(root, engine_config, io)
         @root = root
         @engine_config = engine_config
@@ -38,7 +40,7 @@ module CC
         return root unless engine_config.has_key?("include_paths")
 
         markdown_files = engine_config["include_paths"].select do |path|
-          path.end_with?(".md")
+          EXTENSIONS.include?(File.extname(path))
         end
 
         Shellwords.join(markdown_files)

--- a/spec/cc/engine/markdownlint_spec.rb
+++ b/spec/cc/engine/markdownlint_spec.rb
@@ -30,6 +30,26 @@ module CC
           CC::Engine::Markdownlint.new(path, {"include_paths" => []}, io).run
           expect(io.string.strip.length).to eq(0)
         end
+
+        it "returns issue when config supplies include_paths" do
+          io = StringIO.new
+          path = File.expand_path("../../fixtures", File.dirname(__FILE__))
+          Dir.chdir(path) do
+            CC::Engine::Markdownlint.new(path, {"include_paths" => ["./"]}, io).run
+            issues = io.string.split("\0")
+            issue = JSON.parse(issues.first)
+
+            expect(issue["type"]).to eq("issue")
+            expect(issue["categories"]).to eq(["Style"])
+            expect(issue["remediation_points"]).to eq(50_000)
+            expect(issue["description"]).to eq("Header levels should only increment by one level at a time")
+            expect(issue["check_name"]).to eq("MD001")
+            expect(issue["content"]["body"]).to include("This rule is triggered when you skip header levels in a markdown document")
+            expect(issue["location"]["path"]).to eq("FIXTURE.md")
+            expect(issue["location"]["begin"]).to eq(3)
+            expect(issue["location"]["end"]).to eq(3)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
1. Support the `.markdown` extensions when filtering for files directly.
   
   The longer `.markdown` is actually the one endorsed by John Gruber, Markdown's creator. There [are other extensions in use, as well](http://daringfireball.net/linked/2014/01/08/markdown-extension), but I think these two are fine for nowsince they're by far the most used and are what GitHub supports as
   well.
2. Support directories in config-provided `include_paths`
   
   Without this, only Markdown files in the root directory would ever be analyzed. Which is most Markdown, certainly, but not all.
