### PR TITLE
Handle Empty include_paths

### DIFF
--- a/lib/cc/engine/markdownlint.rb
+++ b/lib/cc/engine/markdownlint.rb
@@ -13,6 +13,15 @@ module CC
       end
 
       def run
+        return if include_paths.strip.length == 0
+        run_mdl
+      end
+
+      private
+
+      attr_reader :root, :engine_config, :io, :contents
+
+      def run_mdl
         pid, _, out, err = POSIX::Spawn.popen4("mdl --no-warnings #{include_paths}")
         out.each_line do |line|
           io.print JSON.dump(issue(line))
@@ -24,10 +33,6 @@ module CC
 
         Process::waitpid(pid)
       end
-
-      private
-
-      attr_reader :root, :engine_config, :io, :contents
 
       def include_paths
         return root unless engine_config.has_key?("include_paths")

--- a/spec/cc/engine/markdownlint_spec.rb
+++ b/spec/cc/engine/markdownlint_spec.rb
@@ -23,6 +23,13 @@ module CC
           expect(issue["location"]["begin"]).to eq(3)
           expect(issue["location"]["end"]).to eq(3)
         end
+
+        it "exits cleanly with empty include_paths" do
+          io = StringIO.new
+          path = File.expand_path("../../fixtures", File.dirname(__FILE__))
+          CC::Engine::Markdownlint.new(path, {"include_paths" => []}, io).run
+          expect(io.string.strip.length).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
Empty `include_paths` are a rare but valid case. In `mdl`'s case, they're
a bit troubling because without explicit file args given, the default
behavior is to wait for STDIN. Which, in our case, means hanging until
killed by a timeout.

This does a quick sanity check of the include paths string before
actually running `mdl`.
