### PR TITLE
Suppress Kramdown Warnings

### DIFF
--- a/lib/cc/engine/markdownlint.rb
+++ b/lib/cc/engine/markdownlint.rb
@@ -13,7 +13,7 @@ module CC
       end
 
       def run
-        pid, _, out, err = POSIX::Spawn.popen4("mdl #{include_paths}")
+        pid, _, out, err = POSIX::Spawn.popen4("mdl --no-warnings #{include_paths}")
         out.each_line do |line|
           io.print JSON.dump(issue(line))
           io.print "\0"


### PR DESCRIPTION
`mdl`'s default behavior is to [print any warnings from Kramdown](https://github.com/mivok/markdownlint/blob/346bfceb7ff85cbbe483c5dea78c7712015a0421/lib/mdl.rb#L76-L81), and to
print them to stdout.

These might be helpful warnings to emit to stderr ourselves, but for the
moment at least we should probably just not get them, since they are a
slightly different format from issues, and  would result in invalid
output from the engine.
