### PR TITLE
readup contents: fix initial headers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,7 @@ namespace :docs do
       if line.start_with?("## MD")
         content.write
         content = Content.new(line[/(MD\d+)/])
+        line = line[1..-1]
       end
 
       content << line


### PR DESCRIPTION
The headers in the original doc are h3's, but they should get pushed up
to h1's for readup contents when extracted.

cc @jpignata
