### PR TITLE
Generate a unique fingerprint per issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - make image
+
+test:
+  override:
+    - make test

--- a/spec/cc/engine/markdownlint_spec.rb
+++ b/spec/cc/engine/markdownlint_spec.rb
@@ -50,6 +50,22 @@ module CC
             expect(issue["location"]["lines"]["end"]).to eq(3)
           end
         end
+
+        it "returns a unique fingerprint per issue" do
+          io = StringIO.new
+          path = File.expand_path("../../fixtures", File.dirname(__FILE__))
+          Dir.chdir(path) do
+            CC::Engine::Markdownlint.new(path, {"include_paths" => ["./"]}, io).run
+            issues = io.string.split("\0")
+
+            expect(issues.length).to eq 2
+
+            issue_1 = JSON.parse(issues[0])
+            issue_2 = JSON.parse(issues[1])
+
+            expect(issue_1["fingerprint"]).not_to eq issue_2["fingerprint"]
+          end
+        end
       end
     end
   end

--- a/spec/fixtures/FIXTURE.md
+++ b/spec/fixtures/FIXTURE.md
@@ -1,3 +1,5 @@
 # Header
 
-### Subheader
+### Subheader 1
+
+##### Subheader 2


### PR DESCRIPTION
Provide a generated fingerprint to Code Climate to prevent collisions
when the same style issue is reported across multiple lines per file.

Right now the default Code Climate fingerprint algorithm is a
concatenation of the check name and path hashed. Unfortunately this
results in a fair amount of collisions for markdownlint as often a
single issue is present multiple times in a given file.

The fingerprint implemented will use the check name, path, and the
contents of the subject line of the issue with whitespace removed.

cc/ @wfleming
