### PR TITLE
Bump markdownlint to 0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "mdl", git: "https://github.com/wfleming/markdownlint", ref: "8143d80"
+gem "mdl", "~> 0.3.1"
 gem "posix-spawn"
 gem "rake"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,12 @@
-GIT
-  remote: https://github.com/wfleming/markdownlint
-  revision: 8143d80a31b6f803bdc0f0b90ada3971546d167b
-  ref: 8143d80
-  specs:
-    mdl (0.2.1)
-      kramdown (~> 1.8, >= 1.8.0)
-      mixlib-cli (~> 1.5, >= 1.5.0)
-      mixlib-config (~> 2.1, >= 2.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
     kramdown (1.10.0)
+    mdl (0.3.1)
+      kramdown (~> 1.8, >= 1.8.0)
+      mixlib-cli (~> 1.5, >= 1.5.0)
+      mixlib-config (~> 2.1, >= 2.1.0)
     mixlib-cli (1.5.0)
     mixlib-config (2.2.1)
     posix-spawn (0.3.11)
@@ -35,7 +29,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  mdl!
+  mdl (~> 0.3.1)
   posix-spawn
   rake
   rspec

--- a/lib/cc/engine/markdownlint.rb
+++ b/lib/cc/engine/markdownlint.rb
@@ -5,7 +5,7 @@ require "posix/spawn"
 module CC
   module Engine
     class Markdownlint
-      CONFIG_FILE = ".mdlrc".freeze
+      CONFIG_FILE = "./.mdlrc".freeze
       EXTENSIONS = %w[.markdown .md].freeze
 
       def initialize(root, engine_config, io)


### PR DESCRIPTION
- Use relative path to configuration file to work around a bug in
  markdownlint

See: https://github.com/mivok/markdownlint/compare/v0.2.1...v0.3.1

c/ @wfleming @pbrisbin
