### PR TITLE
Migrate to Circle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build_and_test:
+    docker:
+      - image: circleci/python:latest
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
+      - run: chmod +x ./cc-test-reporter
+      - run: ./cc-test-reporter before-build
+      - run: make image
+      - run: make test
+      - run:
+          name: "Upload coverage"
+          command: ./cc-test-reporter after-build --prefix="/usr/src/app"
+          environment:
+              CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
+
+workflows:
+  version: 2
+  build_deploy:
+    jobs:
+      - build_and_test
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.0-slim
+FROM ruby:2.6.3-slim
 
 ENV LANG C.UTF-8
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,4 @@ gem "rake"
 group :test do
   gem "rspec"
   gem "simplecov"
-  gem "codeclimate-test-reporter", "~> 1.0.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    codeclimate-test-reporter (1.0.4)
-      simplecov
     diff-lcs (1.2.5)
     docile (1.1.5)
     json (2.0.2)
@@ -38,7 +36,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  codeclimate-test-reporter (~> 1.0.0)
   mdl (~> 0.4.0)
   posix-spawn
   rake
@@ -46,4 +43,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.13.7
+   1.17.2

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,8 @@ image:
 	docker build --rm -t $(IMAGE_NAME) .
 
 test: image
-	docker run --rm \
-		--env CIRCLECI \
-		--env CIRCLE_BUILD_NUM \
-		--env CIRCLE_BRANCH \
-		--env CIRCLE_SHA1 \
-		--env CODECLIMATE_REPO_TOKEN \
+	docker run \
+		--name "markdownlint-${CIRCLE_WORKFLOW_ID}" \
 		--workdir /usr/src/app \
-		--volume "$(PWD)/.git:/usr/src/app/.git" \
-		$(IMAGE_NAME) sh -c "bundle exec rake && bundle exec codeclimate-test-reporter"
+		$(IMAGE_NAME) bundle exec rake
+	docker cp "markdownlint-${CIRCLE_WORKFLOW_ID}":/usr/src/app/coverage ./coverage


### PR DESCRIPTION
Also took this opportunity to switch to the new test reporter, and bump
Ruby, since the image wasn't building with the old base image.

Opening to help unblock https://github.com/codeclimate-community/codeclimate-markdownlint/pull/23