### PR TITLE
QUA-846: introduce beta channel with mdl 0.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: |
             make citest
             ./cc-test-reporter format-coverage --input-type simplecov
-            ./cc-test-reporter upload-coverage
+            ./cc-test-reporter upload-coverage --prefix "./coverage"
 
   release_images:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,11 @@ jobs:
       - run: ./cc-test-reporter before-build
       - run: make image
       - run:
-          name: "make citest"
-          command: make citest
-          environment:
-              CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
-      - run:
-          name: "Upload coverage"
-          command: ./cc-test-reporter after-build -t simplecov --prefix="/usr/src/app"
+          name: "Run tests and upload coverage"
+          command: |
+            ./cc-test-reporter before-build
+            make citest
+            ./cc-test-reporter after-build -t simplecov --prefix="/usr/src/app"
           environment:
               CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run: ./cc-test-reporter before-build
       - run: make image
       - run:
+        name: "make citest"
         command: make citest
         environment:
           CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,15 @@ jobs:
       - run: ./cc-test-reporter before-build
       - run: make image
       - run:
-        name: "make citest"
-        command: make citest
-        environment:
-          CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
+          name: "make citest"
+          command: make citest
+          environment:
+              CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
       - run:
-        name: "Upload coverage"
-        command: ./cc-test-reporter after-build --prefix="/usr/src/app"
-        environment:
-          CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
+          name: "Upload coverage"
+          command: ./cc-test-reporter after-build --prefix="/usr/src/app"
+          environment:
+              CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
 
   release_images:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ init: &init
       . .circleci/shared.bash
 jobs:
   build_and_test:
+    environment:
+      CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
     machine:
       docker_layer_caching: true
     working_directory: ~/codeclimate/codeclimate-markdownlint
@@ -23,8 +25,6 @@ jobs:
             ./cc-test-reporter before-build
             make citest
             ./cc-test-reporter after-build -t simplecov --prefix="/usr/src/app"
-          environment:
-              CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
 
   release_images:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run: make image
       - run:
           name: "Run tests and upload coverage"
-          command:
+          command: |
             make citest
             ./cc-test-reporter format-coverage --input-type simplecov --prefix "/usr/src/app"
             ./cc-test-reporter upload-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ init: &init
       echo '. .circleci/shared.bash' >> "$BASH_ENV"
       . .circleci/shared.bash
 jobs:
-  build_and_test:
+  build:
     environment:
       CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
     machine:
@@ -15,15 +15,28 @@ jobs:
     working_directory: ~/codeclimate/codeclimate-markdownlint
     steps:
       - checkout
-      - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
-      - run: chmod +x ./cc-test-reporter
-      - run: make image
+      - *init
+      - run: make citest
       - run:
-          name: "Run tests and upload coverage"
+          name: Collect test coverage
           command: |
-            make citest
-            ./cc-test-reporter format-coverage --input-type simplecov
-            ./cc-test-reporter upload-coverage --prefix "./coverage"
+            install_cc_test_reporter
+            cp_test_coverage
+      - persist_to_workspace:
+          root: .
+          paths:
+            - coverage
+
+  report_coverage:
+    environment:
+      CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: echo '. .circleci/shared.bash' >> "$BASH_ENV"
+      - run: install_cc_test_reporter
+      - run: report_test_coverage
 
   release_images:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,16 @@ workflows:
   version: 2
   build_deploy:
     jobs:
-      - build_and_test
+      - build
+      - test:
+          requires:
+            - build
+      - report_coverage:
+          requires:
+            - test
       - release_images:
           requires:
-            - build_and_test
+            - test
           filters:
             branches:
               only: /master|channel\/[\w-]+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,29 +15,12 @@ jobs:
     working_directory: ~/codeclimate/codeclimate-markdownlint
     steps:
       - checkout
-      - *init
+      - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
+      - run: chmod +x ./cc-test-reporter
+      - run: ./cc-test-reporter before-build
       - run: make image
       - run: make citest
-      - run:
-          name: Collect test coverage
-          command: |
-            install_cc_test_reporter
-            cp_test_coverage
-      - persist_to_workspace:
-          root: .
-          paths:
-            - coverage
-
-  report_coverage:
-    environment:
-      CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run: echo '. .circleci/shared.bash' >> "$BASH_ENV"
-      - run: install_cc_test_reporter
-      - run: report_test_coverage
+      - run: ./cc-test-reporter after-build -t simplecov --prefix="/usr/src/app"
 
   release_images:
     machine:
@@ -69,9 +52,6 @@ workflows:
   build_deploy:
     jobs:
       - build_and_test
-      - report_coverage:
-          requires:
-            - build_and_test
       - release_images:
           requires:
             - build_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,53 @@
 version: 2
+
+init: &init
+  run:
+    name: init
+    command: |
+      echo '. .circleci/shared.bash' >> "$BASH_ENV"
+      . .circleci/shared.bash
 jobs:
-  build_and_test:
-    docker:
-      - image: circleci/python:latest
+  build:
+    machine:
+      docker_layer_caching: false
+    working_directory: ~/codeclimate/codeclimate-markdownlint
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-
-      - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
-      - run: chmod +x ./cc-test-reporter
-      - run: ./cc-test-reporter before-build
       - run: make image
-      - run: make citest
+
+  release_images:
+    machine:
+      docker_layer_caching: false
+    working_directory: ~/codeclimate/codeclimate-markdownlint
+    steps:
+      - checkout
+      - *init
       - run:
-          name: "Upload coverage"
-          command: ./cc-test-reporter after-build --prefix="/usr/src/app"
-          environment:
-              CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
+          name: Validate owner
+          command: |
+            if [ "$CIRCLE_PROJECT_USERNAME" -ne "codeclimate" ]
+            then
+              echo "Skipping release for non-codeclimate branches"
+              circleci step halt
+            fi
+      - run: make image
+      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run:
+          name: Push image to GCR
+          command: |
+            docker tag codeclimate/codeclimate-markdownlint \
+              us.gcr.io/code-climate/codeclimate-markdownlint:b$CIRCLE_BUILD_NUM
+            docker push us.gcr.io/code-climate/codeclimate-markdownlint:b$CIRCLE_BUILD_NUM
+      - run: send_webhook
 
 workflows:
   version: 2
   build_deploy:
     jobs:
-      - build_and_test
-notify:
-  webhooks:
-    - url: https://cc-slack-proxy.herokuapp.com/circle
+      - build
+      - release_images:
+          requires:
+            - build
+          filters:
+            branches:
+              only: /master|channel\/[\w-]+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,12 @@ jobs:
       - checkout
       - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
       - run: chmod +x ./cc-test-reporter
-      - run: ./cc-test-reporter before-build
       - run: make image
       - run:
           name: "Run tests and upload coverage"
           command: |
             make citest
-            ./cc-test-reporter format-coverage --input-type simplecov --prefix "/usr/src/app"
+            ./cc-test-reporter format-coverage --input-type simplecov
             ./cc-test-reporter upload-coverage
 
   release_images:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ init: &init
       echo '. .circleci/shared.bash' >> "$BASH_ENV"
       . .circleci/shared.bash
 jobs:
-  build:
+  build_and_test:
     environment:
       CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
     machine:
@@ -16,6 +16,7 @@ jobs:
     steps:
       - checkout
       - *init
+      - run: make image
       - run: make citest
       - run:
           name: Collect test coverage
@@ -67,16 +68,13 @@ workflows:
   version: 2
   build_deploy:
     jobs:
-      - build
-      - test:
-          requires:
-            - build
+      - build_and_test
       - report_coverage:
           requires:
-            - test
+            - build_and_test
       - release_images:
           requires:
-            - test
+            - build_and_test
           filters:
             branches:
               only: /master|channel\/[\w-]+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ init: &init
 jobs:
   build_and_test:
     machine:
-      docker_layer_caching: false
+      docker_layer_caching: true
     working_directory: ~/codeclimate/codeclimate-markdownlint
     steps:
       - checkout
@@ -24,7 +24,7 @@ jobs:
               CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
       - run:
           name: "Upload coverage"
-          command: ./cc-test-reporter after-build --prefix="/usr/src/app"
+          command: ./cc-test-reporter after-build -t simplecov --prefix="/usr/src/app"
           environment:
               CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,15 @@ jobs:
       - run: chmod +x ./cc-test-reporter
       - run: ./cc-test-reporter before-build
       - run: make image
-      - run: make citest
       - run:
-          name: "Upload coverage"
-          command: ./cc-test-reporter after-build --prefix="/usr/src/app"
-          environment:
-              CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
+        command: make citest
+        environment:
+          CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
+      - run:
+        name: "Upload coverage"
+        command: ./cc-test-reporter after-build --prefix="/usr/src/app"
+        environment:
+          CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
 
   release_images:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,22 @@ init: &init
       echo '. .circleci/shared.bash' >> "$BASH_ENV"
       . .circleci/shared.bash
 jobs:
-  build:
+  build_and_test:
     machine:
       docker_layer_caching: false
     working_directory: ~/codeclimate/codeclimate-markdownlint
     steps:
       - checkout
+      - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
+      - run: chmod +x ./cc-test-reporter
+      - run: ./cc-test-reporter before-build
       - run: make image
+      - run: make citest
+      - run:
+          name: "Upload coverage"
+          command: ./cc-test-reporter after-build --prefix="/usr/src/app"
+          environment:
+              CC_TEST_REPORTER_ID: 45c013b6d2380a087f53ebc237a799b3ca09f1a3b05ddf96982637d42a9d6861
 
   release_images:
     machine:
@@ -44,10 +53,10 @@ workflows:
   version: 2
   build_deploy:
     jobs:
-      - build
+      - build_and_test
       - release_images:
           requires:
-            - build
+            - build_and_test
           filters:
             branches:
               only: /master|channel\/[\w-]+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             ./cc-test-reporter before-build
             make citest
-            ./cc-test-reporter after-build -t simplecov --prefix="/usr/src/app"
+            ./cc-test-reporter after-build -t simplecov --prefix "/usr/src/app"
 
   release_images:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
       - run: make image
       - run:
           name: "Run tests and upload coverage"
-          command: |
-            ./cc-test-reporter before-build
+          command:
             make citest
-            ./cc-test-reporter after-build -t simplecov --prefix "/usr/src/app"
+            ./cc-test-reporter format-coverage --input-type simplecov --prefix "/usr/src/app"
+            ./cc-test-reporter upload-coverage
 
   release_images:
     machine:

--- a/.circleci/shared.bash
+++ b/.circleci/shared.bash
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+function commiter_email() {
+  set +x
+  git log -n 1 --format='%ae'
+  set -x
+}
+
+function webhook_payload() {
+  set +x
+  COMMITER_EMAIL=$(commiter_email)
+  CURRENT_DATE=$(date)
+  jq --null-input \
+    --arg reponame $CIRCLE_PROJECT_REPONAME \
+    --arg username $CIRCLE_PROJECT_USERNAME \
+    --arg branch $CIRCLE_BRANCH \
+    --arg build_num $CIRCLE_BUILD_NUM \
+    --arg build_url $CIRCLE_BUILD_URL \
+    --arg author_email $COMMITER_EMAIL \
+    --arg end_time "$CURRENT_DATE" \
+    '{
+      "payload": {
+        "status": "success",
+        "outcome":"success",
+        "username": $username,
+        "reponame": $reponame,
+        "branch": $branch,
+        "build_num": $build_num,
+        "build_url": $build_url,
+        "author_email": $author_email,
+        "steps": [
+          {
+            "actions": [
+              {"end_time": $end_time }
+            ]
+          }
+        ]
+      }
+    }'
+  set -x
+}
+
+function send_webhook() {
+  set +x
+  PAYLOAD=$(webhook_payload)
+  curl -i -X POST https://cc-slack-proxy.herokuapp.com/circle \
+    -H 'Content-Type: application/json' \
+    -d "$PAYLOAD"
+  set -x
+}

--- a/.circleci/shared.bash
+++ b/.circleci/shared.bash
@@ -16,14 +16,11 @@ function cp_test_coverage() {
 
   docker cp "markdownlint-${CIRCLE_WORKFLOW_ID}":/usr/src/app/coverage coverage
 
-  cc-test-reporter format-coverage --input-type simplecov --output "./$output_folder/codeclimate.${CIRCLE_JOB}_${CIRCLE_NODE_INDEX}.json" --prefix "/app"
+  cc-test-reporter format-coverage --input-type simplecov --output "./coverage/codeclimate.json" --prefix "/usr/src/app"
   set -u
 }
 
 function report_test_coverage() {
-  mv coverage_ui/* coverage
-  cc-test-reporter sum-coverage coverage/codeclimate.*.json --parts "$(find coverage/codeclimate.*.json | wc -l)"
-
   cc-test-reporter upload-coverage || echo "report coverage skipped"
 }
 

--- a/.circleci/shared.bash
+++ b/.circleci/shared.bash
@@ -14,7 +14,7 @@ function cp_test_coverage() {
   set +u
   local output_folder="${1:-coverage}"
 
-  docker cp "test-workflow-${CIRCLE_WORKFLOW_ID}-${CIRCLE_JOB}-node-${CIRCLE_NODE_INDEX}":/app/coverage coverage
+  docker cp "markdownlint-${CIRCLE_WORKFLOW_ID}":/app/coverage coverage
 
   cc-test-reporter format-coverage --input-type simplecov --output "./$output_folder/codeclimate.${CIRCLE_JOB}_${CIRCLE_NODE_INDEX}.json" --prefix "/app"
   set -u

--- a/.circleci/shared.bash
+++ b/.circleci/shared.bash
@@ -14,7 +14,7 @@ function cp_test_coverage() {
   set +u
   local output_folder="${1:-coverage}"
 
-  docker cp "markdownlint-${CIRCLE_WORKFLOW_ID}":/app/coverage coverage
+  docker cp "markdownlint-${CIRCLE_WORKFLOW_ID}":/usr/src/app/coverage coverage
 
   cc-test-reporter format-coverage --input-type simplecov --output "./$output_folder/codeclimate.${CIRCLE_JOB}_${CIRCLE_NODE_INDEX}.json" --prefix "/app"
   set -u

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.3-slim
+FROM ruby:2.7.7-alpine3.16
 
 ENV LANG C.UTF-8
 
@@ -7,12 +7,12 @@ WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
 
-RUN apt-get update && \
-    apt-get install -y build-essential git && \
+RUN apk update && \
+    apk add build-base git && \
     bundle && \
-    apt-get remove -y build-essential
+    apk del build-base
 
-RUN adduser --uid 9000 --disabled-password --quiet --gecos "app" app
+RUN adduser -u 9000 -D -g "app" app
 COPY . /usr/src/app
 RUN chown -R app:app /usr/src/app
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "mdl", "~> 0.5.0"
+gem "mdl", "~> 0.12.0"
 gem "posix-spawn"
 gem "rake"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,48 +1,59 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    docile (1.1.5)
-    json (2.0.2)
-    kramdown (1.17.0)
-    mdl (0.5.0)
-      kramdown (~> 1.12, >= 1.12.0)
-      mixlib-cli (~> 1.7, >= 1.7.0)
-      mixlib-config (~> 2.2, >= 2.2.1)
-    mixlib-cli (1.7.0)
-    mixlib-config (2.2.18)
+    chef-utils (18.0.185)
+      concurrent-ruby
+    concurrent-ruby (1.1.10)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    mdl (0.12.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
       tomlrb
-    posix-spawn (0.3.11)
-    rake (11.3.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    mixlib-shellout (3.2.7)
+      chef-utils
+    posix-spawn (0.3.15)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
-    simplecov (0.12.0)
-      docile (~> 1.1.0)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
-    tomlrb (1.2.8)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    tomlrb (2.0.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  mdl (~> 0.5.0)
+  mdl (~> 0.12.0)
   posix-spawn
   rake
   rspec
   simplecov
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,9 @@ citest: image
 	docker run \
 		--name "markdownlint-${CIRCLE_WORKFLOW_ID}" \
 		--workdir /usr/src/app \
-		$(IMAGE_NAME) bundle exec rake
-	docker cp "markdownlint-${CIRCLE_WORKFLOW_ID}":/usr/src/app/coverage ./coverage
+		$(IMAGE_NAME) bundle exec rspec
 
 test: image
 	docker run \
 		--workdir /usr/src/app \
-		$(IMAGE_NAME) bundle exec rake
+		$(IMAGE_NAME) bundle exec rspec

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ citest: image
 	docker run \
 		--name "markdownlint-${CIRCLE_WORKFLOW_ID}" \
 		--workdir /usr/src/app \
-		$(IMAGE_NAME) bundle exec rspec
+		$(IMAGE_NAME) bundle exec rake
+	docker cp "markdownlint-${CIRCLE_WORKFLOW_ID}":/usr/src/app/coverage ./coverage
 
 test: image
 	docker run \
 		--workdir /usr/src/app \
-		$(IMAGE_NAME) bundle exec rspec
+		$(IMAGE_NAME) bundle exec rake

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 require "simplecov"
+require "simplecov_json_formatter"
+
+SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
 
 SimpleCov.start do
   add_filter "/spec/"


### PR DESCRIPTION
This PR introduces a beta channel in the engine that uses the `mdl` gem version 0.12.0.

Other changes include:

- Update the base image to `ruby:2.7.7-alpine3.16`. This was required for `mdl` `0.12.0` to work, since it's only compatible with ruby 2.7 onwards
- For the sake of making the engine a bit more future proof, I set the engine to use the gem's `--json` mode instead of the default mode. This outputs only one line that we can parse, instead of multiple lines that we have to check for the correct format.
- Change the CircleCI config to use the more recent one that sends the supported webhook payload to shipbot